### PR TITLE
Bug: Invalid dialog options for '-p' option

### DIFF
--- a/scripts/sbin/drbl-functions
+++ b/scripts/sbin/drbl-functions
@@ -1462,8 +1462,9 @@ ocs_advanced_param_post_mode_after_clone() {
   if [ -z "$ocs_postmode" ]; then
     # //NOTE// Extra space is required in the --default-item.
     $DIA --backtitle "$msg_nchc_free_software_labs" --title  \
-    "$msg_clonezilla_advanced_extra_param | $msg_mode: $ocs_mode_prompt" --menu "$msg_choose_post_mode_after_clone:" \
+    "$msg_clonezilla_advanced_extra_param | $msg_mode: $ocs_mode_prompt"
     --default-item "-p $default_postaction " \
+    --menu "$msg_choose_post_mode_after_clone:" \
     0 0 0 $DIA_ESC \
     "-p reboot "    "$msg_ocs_param_p_reboot" \
     "-p poweroff "  "$msg_ocs_param_p_poweroff" \


### PR DESCRIPTION
The `--default-item` option was misplaced (it come right after `--menu`) in `-p` option dialog. This caused error for `$DIA=dialog`  (`whiptail` is fine for both old and new options order).